### PR TITLE
Change GenerateMenuElement visibility from protected to public

### DIFF
--- a/Plugin/ConfigEntryFactory.cs
+++ b/Plugin/ConfigEntryFactory.cs
@@ -82,7 +82,7 @@ public class ConfigEntryFactory
     /// Right now only booleans, enums, and entries with an explicit AcceptableValuesList are supported.
     /// In the future support for numeric and other types may be added.
     /// </summary>
-    protected virtual bool GenerateMenuElement(
+    public virtual bool GenerateMenuElement(
         ConfigEntryBase entry,
         [MaybeNullWhen(false)] out MenuElement menuElement
     )


### PR DESCRIPTION
Use case: I want to create a custom menu with subpages. I want to use the config entry factory to convert my ConfigEntryBase entries to elements. I can't use GenerateEntryButton because that puts all elements on the same page.