### PR TITLE
Fix documentation link to the wrong page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ The standard menu-modification mod for Silksong. It provides a small but powerfu
 
 This mod also adds a 'Mod Options' menu to the main Options menu by default.
 
-For documentation and examples, see the [documentation](https://docs.silksong-modding.org/Silksong.DataManager).
+For documentation and examples, see the [documentation](https://docs.silksong-modding.org/Silksong.ModMenu/).


### PR DESCRIPTION
### Summary of Changes

This PR change the documentation link to the actual ModMenu documentation, which is linked to DataManager before this change.

### Checklist

* No change is too small for a release, so pick one:
  * [ ] I have updated the package version following semantic versioning
  * [ ] There is another change actively WIP that will update the version (link issue or PR here)
  * [x] This PR does not update user-facing code/config
  * [ ] I'm not sure how to set the version and would like the reviewer's help
  
