### PR TITLE
Add a Generic Numeric TextModel

### DIFF
--- a/Silksong.ModMenu/Models/TextModels.cs
+++ b/Silksong.ModMenu/Models/TextModels.cs
@@ -41,20 +41,13 @@ public static class TextModels
     public static ParserTextModel<T> ForNumbers<T>()
         where T : struct, IComparable<T>
     {
-        if (!numericTryParses.TryGetValue(typeof(T), out var tryParse))
+        if (!numericParsers.TryGetValue(typeof(T), out var parser))
             throw new ArgumentException($"{typeof(T)} is not a numeric value type.");
 
-        if (!numericModelParsers.TryGetValue(typeof(T), out var parser))
-            numericModelParsers[typeof(T)] = parser = tryParse.Value.CreateDelegate(
-                typeof(ParserTextModel<T>.Parse)
-            );
-
-        return new((ParserTextModel<T>.Parse)parser, DefaultUnparse);
+        return new((ParserTextModel<T>.Parse)parser.Value, DefaultUnparse);
     }
 
-    private static readonly Dictionary<Type, Delegate> numericModelParsers = [];
-
-    private static readonly Dictionary<Type, Lazy<MethodInfo>> numericTryParses = new Type[]
+    private static readonly Dictionary<Type, Lazy<Delegate>> numericParsers = new Type[]
     {
         typeof(byte),
         typeof(sbyte),
@@ -69,7 +62,7 @@ public static class TextModels
         typeof(decimal),
     }.ToDictionary(
         k => k,
-        v => new Lazy<MethodInfo>(() =>
+        v => new Lazy<Delegate>(() =>
             v.GetMethods(BindingFlags.Public | BindingFlags.Static)
                 .First(m =>
                 {
@@ -79,6 +72,7 @@ public static class TextModels
                         && args[0].ParameterType == typeof(string)
                         && args[1].IsOut;
                 })
+                .CreateDelegate(typeof(ParserTextModel<>.Parse).MakeGenericType(v))
         )
     );
 

--- a/Silksong.ModMenu/Models/TextModels.cs
+++ b/Silksong.ModMenu/Models/TextModels.cs
@@ -18,33 +18,99 @@ public static class TextModels
         new(DefaultUnparse<string>, DefaultUnparse<string>);
 
     /// <summary>
-    /// An ITextModel which parses its input into an integer.
+    /// An ITextModel which parses its input into into <typeparamref name="T"/> values clamped between a min and max.
     /// </summary>
-    public static ParserTextModel<int> ForIntegers() => new(int.TryParse, DefaultUnparse<int>);
-
-    /// <summary>
-    /// An ITextModel which parses its input into an integer clamped between a min and max.
-    /// </summary>
-    public static ParserTextModel<int> ForIntegers(int min, int max)
+    /// <remarks>
+    /// Only works with numeric value types such as <see langword="int"/>, <see langword="float"/>, etc.
+    /// </remarks>
+    public static ParserTextModel<T> ForNumbers<T>(T min, T max)
+        where T : struct, IComparable<T>
     {
-        var model = ForIntegers();
+        var model = ForNumbers<T>();
         model.ConstraintFn = RangeConstraint(min, max);
         return model;
     }
 
     /// <summary>
-    /// An ITextModel which parses its input into a float.
+    /// An ITextModel which parses its input into <typeparamref name="T"/> values.
     /// </summary>
-    public static ParserTextModel<float> ForFloats() => new(float.TryParse, DefaultUnparse<float>);
-
-    /// <summary>
-    /// An ITextModel which parses its input into a float clamped between a min and max.
-    /// </summary>
-    public static ParserTextModel<float> ForFloats(float min, float max)
+    /// <remarks>
+    /// Only works with numeric value types such as <see langword="int"/>, <see langword="float"/>, etc.
+    /// </remarks>
+    public static ParserTextModel<T> ForNumbers<T>()
+        where T : struct, IComparable<T>
     {
-        var model = ForFloats();
-        model.ConstraintFn = RangeConstraint(min, max);
-        return model;
+        ParserTextModel<T>.Parse parser = default(T) switch
+        {
+            byte => static (text, out value) =>
+            {
+                bool res = byte.TryParse(text, out byte parsed);
+                value = (T)(object)parsed;
+                return res;
+            },
+            sbyte => static (text, out value) =>
+            {
+                bool res = sbyte.TryParse(text, out sbyte parsed);
+                value = (T)(object)parsed;
+                return res;
+            },
+            short => static (text, out value) =>
+            {
+                bool res = short.TryParse(text, out short parsed);
+                value = (T)(object)parsed;
+                return res;
+            },
+            ushort => static (text, out value) =>
+            {
+                bool res = ushort.TryParse(text, out ushort parsed);
+                value = (T)(object)parsed;
+                return res;
+            },
+            int => static (text, out value) =>
+            {
+                bool res = int.TryParse(text, out int parsed);
+                value = (T)(object)parsed;
+                return res;
+            },
+            uint => static (text, out value) =>
+            {
+                bool res = uint.TryParse(text, out uint parsed);
+                value = (T)(object)parsed;
+                return res;
+            },
+            long => static (text, out value) =>
+            {
+                bool res = long.TryParse(text, out long parsed);
+                value = (T)(object)parsed;
+                return res;
+            },
+            ulong => static (text, out value) =>
+            {
+                bool res = ulong.TryParse(text, out ulong parsed);
+                value = (T)(object)parsed;
+                return res;
+            },
+            float => static (text, out value) =>
+            {
+                bool res = float.TryParse(text, out float parsed);
+                value = (T)(object)parsed;
+                return res;
+            },
+            double => static (text, out value) =>
+            {
+                bool res = double.TryParse(text, out double parsed);
+                value = (T)(object)parsed;
+                return res;
+            },
+            decimal => static (text, out value) =>
+            {
+                bool res = decimal.TryParse(text, out decimal parsed);
+                value = (T)(object)parsed;
+                return res;
+            },
+            _ => throw new ArgumentException($"{typeof(T)} is not a numeric value type."),
+        };
+        return new(parser, DefaultUnparse);
     }
 
     private static bool DefaultUnparse<T>(T value, out string text)

--- a/Silksong.ModMenu/Models/TextModels.cs
+++ b/Silksong.ModMenu/Models/TextModels.cs
@@ -44,16 +44,15 @@ public static class TextModels
         if (!numericTryParses.TryGetValue(typeof(T), out var tryParse))
             throw new ArgumentException($"{typeof(T)} is not a numeric value type.");
 
-        ParserTextModel<T>.Parse modelParser = (text, out value) =>
-        {
-            object[] args = [text, default(T)];
-            bool result = (bool)tryParse.Value.Invoke(null, args);
-            value = (T)args[1];
-            return result;
-        };
+        if (!numericModelParsers.TryGetValue(typeof(T), out var parser))
+            numericModelParsers[typeof(T)] = parser = tryParse.Value.CreateDelegate(
+                typeof(ParserTextModel<T>.Parse)
+            );
 
-        return new(modelParser, DefaultUnparse);
+        return new((ParserTextModel<T>.Parse)parser, DefaultUnparse);
     }
+
+    private static readonly Dictionary<Type, Delegate> numericModelParsers = [];
 
     private static readonly Dictionary<Type, Lazy<MethodInfo>> numericTryParses = new Type[]
     {

--- a/Silksong.ModMenu/Models/TextModels.cs
+++ b/Silksong.ModMenu/Models/TextModels.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Silksong.ModMenu.Internal;
 using UnityEngine;
 
@@ -40,78 +41,47 @@ public static class TextModels
     public static ParserTextModel<T> ForNumbers<T>()
         where T : struct, IComparable<T>
     {
-        ParserTextModel<T>.Parse parser = default(T) switch
+        if (!numericTryParses.TryGetValue(typeof(T), out var tryParse))
+            throw new ArgumentException($"{typeof(T)} is not a numeric value type.");
+
+        ParserTextModel<T>.Parse modelParser = (text, out value) =>
         {
-            byte => static (text, out value) =>
-            {
-                bool res = byte.TryParse(text, out byte parsed);
-                value = (T)(object)parsed;
-                return res;
-            },
-            sbyte => static (text, out value) =>
-            {
-                bool res = sbyte.TryParse(text, out sbyte parsed);
-                value = (T)(object)parsed;
-                return res;
-            },
-            short => static (text, out value) =>
-            {
-                bool res = short.TryParse(text, out short parsed);
-                value = (T)(object)parsed;
-                return res;
-            },
-            ushort => static (text, out value) =>
-            {
-                bool res = ushort.TryParse(text, out ushort parsed);
-                value = (T)(object)parsed;
-                return res;
-            },
-            int => static (text, out value) =>
-            {
-                bool res = int.TryParse(text, out int parsed);
-                value = (T)(object)parsed;
-                return res;
-            },
-            uint => static (text, out value) =>
-            {
-                bool res = uint.TryParse(text, out uint parsed);
-                value = (T)(object)parsed;
-                return res;
-            },
-            long => static (text, out value) =>
-            {
-                bool res = long.TryParse(text, out long parsed);
-                value = (T)(object)parsed;
-                return res;
-            },
-            ulong => static (text, out value) =>
-            {
-                bool res = ulong.TryParse(text, out ulong parsed);
-                value = (T)(object)parsed;
-                return res;
-            },
-            float => static (text, out value) =>
-            {
-                bool res = float.TryParse(text, out float parsed);
-                value = (T)(object)parsed;
-                return res;
-            },
-            double => static (text, out value) =>
-            {
-                bool res = double.TryParse(text, out double parsed);
-                value = (T)(object)parsed;
-                return res;
-            },
-            decimal => static (text, out value) =>
-            {
-                bool res = decimal.TryParse(text, out decimal parsed);
-                value = (T)(object)parsed;
-                return res;
-            },
-            _ => throw new ArgumentException($"{typeof(T)} is not a numeric value type."),
+            object[] args = [text, default(T)];
+            bool result = (bool)tryParse.Value.Invoke(null, args);
+            value = (T)args[1];
+            return result;
         };
-        return new(parser, DefaultUnparse);
+
+        return new(modelParser, DefaultUnparse);
     }
+
+    private static readonly Dictionary<Type, Lazy<MethodInfo>> numericTryParses = new Type[]
+    {
+        typeof(byte),
+        typeof(sbyte),
+        typeof(short),
+        typeof(ushort),
+        typeof(int),
+        typeof(uint),
+        typeof(long),
+        typeof(ulong),
+        typeof(float),
+        typeof(double),
+        typeof(decimal),
+    }.ToDictionary(
+        k => k,
+        v => new Lazy<MethodInfo>(() =>
+            v.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .First(m =>
+                {
+                    var args = m.GetParameters();
+                    return m.Name == "TryParse"
+                        && args.Length == 2
+                        && args[0].ParameterType == typeof(string)
+                        && args[1].IsOut;
+                })
+        )
+    );
 
     private static bool DefaultUnparse<T>(T value, out string text)
     {

--- a/Silksong.ModMenu/Plugin/ConfigEntryFactory.cs
+++ b/Silksong.ModMenu/Plugin/ConfigEntryFactory.cs
@@ -33,8 +33,7 @@ public class ConfigEntryFactory
         GenerateEnumChoiceElement,
         GenerateAcceptableValuesChoiceElement,
         GenerateBoolElement,
-        GenerateIntElement,
-        GenerateFloatElement,
+        GenerateNumberElement,
         GenerateStringElement,
         GenerateColorElement,
     ];
@@ -354,57 +353,151 @@ public class ConfigEntryFactory
     }
 
     /// <summary>
-    /// Generates a menu element for a config setting with a free or ranged int value.
+    /// Generates a menu element for a config setting with a free or ranged numeric value.
     /// </summary>
-    public static bool GenerateIntElement(
+    public static bool GenerateNumberElement(
         ConfigEntryBase entry,
         [MaybeNullWhen(false)] out MenuElement menuElement
     )
     {
-        if (entry is not ConfigEntry<int> intEntry)
+        switch (entry)
         {
-            menuElement = default;
-            return false;
+            case ConfigEntry<byte> byteEntry:
+                TextInput<byte> byteText = new(
+                    entry.LabelName(),
+                    (entry.Description.AcceptableValues is AcceptableValueRange<byte> byteRange)
+                        ? TextModels.ForNumbers(byteRange.MinValue, byteRange.MaxValue)
+                        : TextModels.ForNumbers<byte>(),
+                    entry.DescriptionLine()
+                );
+                byteText.SynchronizeWith(byteEntry);
+                menuElement = byteText;
+                return true;
+
+            case ConfigEntry<sbyte> sbyteEntry:
+                TextInput<sbyte> sbyteText = new(
+                    entry.LabelName(),
+                    (entry.Description.AcceptableValues is AcceptableValueRange<sbyte> sbyteRange)
+                        ? TextModels.ForNumbers(sbyteRange.MinValue, sbyteRange.MaxValue)
+                        : TextModels.ForNumbers<sbyte>(),
+                    entry.DescriptionLine()
+                );
+                sbyteText.SynchronizeWith(sbyteEntry);
+                menuElement = sbyteText;
+                return true;
+
+            case ConfigEntry<short> shortEntry:
+                TextInput<short> shortText = new(
+                    entry.LabelName(),
+                    (entry.Description.AcceptableValues is AcceptableValueRange<short> shortRange)
+                        ? TextModels.ForNumbers(shortRange.MinValue, shortRange.MaxValue)
+                        : TextModels.ForNumbers<short>(),
+                    entry.DescriptionLine()
+                );
+                shortText.SynchronizeWith(shortEntry);
+                menuElement = shortText;
+                return true;
+
+            case ConfigEntry<ushort> ushortEntry:
+                TextInput<ushort> ushortText = new(
+                    entry.LabelName(),
+                    (entry.Description.AcceptableValues is AcceptableValueRange<ushort> ushortRange)
+                        ? TextModels.ForNumbers(ushortRange.MinValue, ushortRange.MaxValue)
+                        : TextModels.ForNumbers<ushort>(),
+                    entry.DescriptionLine()
+                );
+                ushortText.SynchronizeWith(ushortEntry);
+                menuElement = ushortText;
+                return true;
+
+            case ConfigEntry<int> intEntry:
+                TextInput<int> intText = new(
+                    entry.LabelName(),
+                    (entry.Description.AcceptableValues is AcceptableValueRange<int> intRange)
+                        ? TextModels.ForNumbers(intRange.MinValue, intRange.MaxValue)
+                        : TextModels.ForNumbers<int>(),
+                    entry.DescriptionLine()
+                );
+                intText.SynchronizeWith(intEntry);
+                menuElement = intText;
+                return true;
+
+            case ConfigEntry<uint> uintEntry:
+                TextInput<uint> uintText = new(
+                    entry.LabelName(),
+                    (entry.Description.AcceptableValues is AcceptableValueRange<uint> uintRange)
+                        ? TextModels.ForNumbers(uintRange.MinValue, uintRange.MaxValue)
+                        : TextModels.ForNumbers<uint>(),
+                    entry.DescriptionLine()
+                );
+                uintText.SynchronizeWith(uintEntry);
+                menuElement = uintText;
+                return true;
+
+            case ConfigEntry<long> longEntry:
+                TextInput<long> longText = new(
+                    entry.LabelName(),
+                    (entry.Description.AcceptableValues is AcceptableValueRange<long> longRange)
+                        ? TextModels.ForNumbers(longRange.MinValue, longRange.MaxValue)
+                        : TextModels.ForNumbers<long>(),
+                    entry.DescriptionLine()
+                );
+                longText.SynchronizeWith(longEntry);
+                menuElement = longText;
+                return true;
+
+            case ConfigEntry<ulong> ulongEntry:
+                TextInput<ulong> ulongText = new(
+                    entry.LabelName(),
+                    (entry.Description.AcceptableValues is AcceptableValueRange<ulong> ulongRange)
+                        ? TextModels.ForNumbers(ulongRange.MinValue, ulongRange.MaxValue)
+                        : TextModels.ForNumbers<ulong>(),
+                    entry.DescriptionLine()
+                );
+                ulongText.SynchronizeWith(ulongEntry);
+                menuElement = ulongText;
+                return true;
+
+            case ConfigEntry<float> floatEntry:
+                TextInput<float> floatText = new(
+                    entry.LabelName(),
+                    (entry.Description.AcceptableValues is AcceptableValueRange<float> floatRange)
+                        ? TextModels.ForNumbers(floatRange.MinValue, floatRange.MaxValue)
+                        : TextModels.ForNumbers<float>(),
+                    entry.DescriptionLine()
+                );
+                floatText.SynchronizeWith(floatEntry);
+                menuElement = floatText;
+                return true;
+
+            case ConfigEntry<double> doubleEntry:
+                TextInput<double> doubleText = new(
+                    entry.LabelName(),
+                    (entry.Description.AcceptableValues is AcceptableValueRange<double> doubleRange)
+                        ? TextModels.ForNumbers(doubleRange.MinValue, doubleRange.MaxValue)
+                        : TextModels.ForNumbers<double>(),
+                    entry.DescriptionLine()
+                );
+                doubleText.SynchronizeWith(doubleEntry);
+                menuElement = doubleText;
+                return true;
+
+            case ConfigEntry<decimal> decimalEntry:
+                TextInput<decimal> decimalText = new(
+                    entry.LabelName(),
+                    (entry.Description.AcceptableValues is AcceptableValueRange<decimal> decRange)
+                        ? TextModels.ForNumbers(decRange.MinValue, decRange.MaxValue)
+                        : TextModels.ForNumbers<decimal>(),
+                    entry.DescriptionLine()
+                );
+                decimalText.SynchronizeWith(decimalEntry);
+                menuElement = decimalText;
+                return true;
+
+            default:
+                menuElement = default;
+                return false;
         }
-
-        var acceptableValues = entry.Description.AcceptableValues;
-        var model =
-            (acceptableValues is AcceptableValueRange<int> range)
-                ? TextModels.ForIntegers(range.MinValue, range.MaxValue)
-                : TextModels.ForIntegers();
-
-        TextInput<int> text = new(entry.LabelName(), model, entry.DescriptionLine());
-        text.SynchronizeWith(intEntry);
-
-        menuElement = text;
-        return true;
-    }
-
-    /// <summary>
-    /// Generates a menu element for a config setting with a free or ranged float value.
-    /// </summary>
-    public static bool GenerateFloatElement(
-        ConfigEntryBase entry,
-        [MaybeNullWhen(false)] out MenuElement menuElement
-    )
-    {
-        if (entry is not ConfigEntry<float> floatEntry)
-        {
-            menuElement = default;
-            return false;
-        }
-
-        var acceptableValues = entry.Description.AcceptableValues;
-        var model =
-            (acceptableValues is AcceptableValueRange<float> range)
-                ? TextModels.ForFloats(range.MinValue, range.MaxValue)
-                : TextModels.ForFloats();
-
-        TextInput<float> text = new(entry.LabelName(), model, entry.DescriptionLine());
-        text.SynchronizeWith(floatEntry);
-
-        menuElement = text;
-        return true;
     }
 
     /// <summary>


### PR DESCRIPTION
### Summary of Changes

I know that #76 is currently slated to add support for auto-generating elements for the missing numeric value types. But I had an idea for how to reduce the number of public API methods there are that are dedicated to just creating TextModels for numbers and I wanted to propose it.

This replaces `TextModels.ForIntegers` and `ForFloats` with a method `ForNumbers<T>` that works for any of the built-in numeric value types. (Edited): The idea is that we keep a dictionary of numeric value types and their TryParse functions, and if the type parameter is in the dictionary, it creates a parser function using the reflected TryParse and returns a model for that. When passed a non-numeric type, it throws an ArgumentException instead.

The ConfigEntryFactory methods `GenerateIntegerElement` and `GenerateFloatElement` have similarly been replaced with a method `GenerateNumberElement` that catches all numeric value types.

I've tested it with the automatic menu test and haven't encountered any problems with any of the types.

I understand if this gets canned for being too clever/code smelly, lol, but I wanted to offer it anyway.

(Also, version has not been bumped due to the many open PRs at the moment)

### Checklist

* No change is too small for a release, so pick one:
  * [ ] I have updated the package version following semantic versioning
  * [ ] There is another change actively WIP that will update the version (link issue or PR here)
  * [ ] This PR does not update user-facing code/config
  * [ ] I'm not sure how to set the version and would like the reviewer's help
  
