### PR TITLE
More intuitive navigation between groups

### DIFF
--- a/Silksong.ModMenu/Directory.Build.props
+++ b/Silksong.ModMenu/Directory.Build.props
@@ -11,6 +11,6 @@
     It should follow the format major.minor.patch (semantic versioning). If you publish your mod
     as a library to NuGet, this version will also be used as the package version.
     -->
-    <Version>0.7.4</Version>
+    <Version>0.8.0</Version>
   </PropertyGroup>
 </Project>

--- a/Silksong.ModMenu/Elements/AbstractGroup.cs
+++ b/Silksong.ModMenu/Elements/AbstractGroup.cs
@@ -85,9 +85,9 @@ public abstract class AbstractGroup : MenuDisposable, INavigableMenuEntity
             .FirstOrDefault();
 
     /// <inheritdoc/>
-    public abstract bool GetSelectable(
+    public abstract bool GetSelectables(
         NavigationDirection direction,
-        [MaybeNullWhen(false)] out Selectable selectable
+        [MaybeNullWhen(false)] out IEnumerable<Selectable> selectable
     );
 
     private GameObject? gameObjectParent;
@@ -113,7 +113,10 @@ public abstract class AbstractGroup : MenuDisposable, INavigableMenuEntity
     }
 
     /// <inheritdoc/>
-    public virtual void SetNeighbor(NavigationDirection direction, Selectable selectable)
+    public virtual void SetNeighbor(
+        NavigationDirection direction,
+        IEnumerable<Selectable> selectable
+    )
     {
         foreach (var navigable in GetNavigables(direction))
             navigable.SetNeighbor(direction, selectable);

--- a/Silksong.ModMenu/Elements/AbstractGroup.cs
+++ b/Silksong.ModMenu/Elements/AbstractGroup.cs
@@ -60,19 +60,19 @@ public abstract class AbstractGroup : MenuDisposable, INavigableMenuEntity
     protected abstract IEnumerable<INavigable> GetNavigables(NavigationDirection direction);
 
     /// <inheritdoc/>
-    public virtual void ClearNeighbor(NavigationDirection direction)
+    public virtual void ClearNeighbors(NavigationDirection direction)
     {
         foreach (var navigable in GetNavigables(direction))
-            navigable.ClearNeighbor(direction);
+            navigable.ClearNeighbors(direction);
     }
 
     /// <inheritdoc/>
     public virtual void ClearNeighbors()
     {
-        ClearNeighbor(NavigationDirection.Up);
-        ClearNeighbor(NavigationDirection.Left);
-        ClearNeighbor(NavigationDirection.Right);
-        ClearNeighbor(NavigationDirection.Down);
+        ClearNeighbors(NavigationDirection.Up);
+        ClearNeighbors(NavigationDirection.Left);
+        ClearNeighbors(NavigationDirection.Right);
+        ClearNeighbors(NavigationDirection.Down);
     }
 
     /// <inheritdoc/>
@@ -87,7 +87,7 @@ public abstract class AbstractGroup : MenuDisposable, INavigableMenuEntity
     /// <inheritdoc/>
     public abstract bool GetSelectables(
         NavigationDirection direction,
-        [MaybeNullWhen(false)] out IEnumerable<Selectable> selectable
+        [MaybeNullWhen(false)] out IEnumerable<Selectable> selectables
     );
 
     private GameObject? gameObjectParent;
@@ -113,13 +113,13 @@ public abstract class AbstractGroup : MenuDisposable, INavigableMenuEntity
     }
 
     /// <inheritdoc/>
-    public virtual void SetNeighbor(
+    public virtual void SetNeighbors(
         NavigationDirection direction,
-        IEnumerable<Selectable> selectable
+        IEnumerable<Selectable> selectables
     )
     {
         foreach (var navigable in GetNavigables(direction))
-            navigable.SetNeighbor(direction, selectable);
+            navigable.SetNeighbors(direction, selectables);
     }
 
     /// <inheritdoc/>

--- a/Silksong.ModMenu/Elements/FreeGroup.cs
+++ b/Silksong.ModMenu/Elements/FreeGroup.cs
@@ -88,13 +88,13 @@ public class FreeGroup : AbstractGroup
         };
 
     /// <inheritdoc/>
-    public override bool GetSelectable(
+    public override bool GetSelectables(
         NavigationDirection direction,
-        [MaybeNullWhen(false)] out Selectable selectable
+        [MaybeNullWhen(false)] out IEnumerable<Selectable> selectable
     )
     {
         selectable = GetNavigables(direction)
-            .Select(n => n.GetSelectable(direction, out var s) ? s : null)
+            .Select(n => n.GetSelectables(direction, out var s) ? s : null)
             .FirstOrDefault();
         return selectable != null;
     }

--- a/Silksong.ModMenu/Elements/FreeGroup.cs
+++ b/Silksong.ModMenu/Elements/FreeGroup.cs
@@ -93,7 +93,7 @@ public class FreeGroup : AbstractGroup
         [MaybeNullWhen(false)] out IEnumerable<Selectable> selectables
     )
     {
-        selectables = GetNavigables(direction)
+        selectables = GetNavigables(direction.Opposite())
             .SelectMany(n => n.GetSelectables(direction, out var s) ? s : null);
         return selectables != null;
     }

--- a/Silksong.ModMenu/Elements/FreeGroup.cs
+++ b/Silksong.ModMenu/Elements/FreeGroup.cs
@@ -94,8 +94,8 @@ public class FreeGroup : AbstractGroup
     )
     {
         selectables = GetNavigables(direction.Opposite())
-            .SelectMany(n => n.GetSelectables(direction, out var s) ? s : null);
-        return selectables != null;
+            .SelectMany(n => n.GetSelectables(direction, out var s) ? s : []);
+        return selectables.Any();
     }
 
     /// <inheritdoc/>

--- a/Silksong.ModMenu/Elements/FreeGroup.cs
+++ b/Silksong.ModMenu/Elements/FreeGroup.cs
@@ -90,13 +90,12 @@ public class FreeGroup : AbstractGroup
     /// <inheritdoc/>
     public override bool GetSelectables(
         NavigationDirection direction,
-        [MaybeNullWhen(false)] out IEnumerable<Selectable> selectable
+        [MaybeNullWhen(false)] out IEnumerable<Selectable> selectables
     )
     {
-        selectable = GetNavigables(direction)
-            .Select(n => n.GetSelectables(direction, out var s) ? s : null)
-            .FirstOrDefault();
-        return selectable != null;
+        selectables = GetNavigables(direction)
+            .SelectMany(n => n.GetSelectables(direction, out var s) ? s : null);
+        return selectables != null;
     }
 
     /// <inheritdoc/>

--- a/Silksong.ModMenu/Elements/GridGroup.cs
+++ b/Silksong.ModMenu/Elements/GridGroup.cs
@@ -150,36 +150,27 @@ public class GridGroup(int columns) : AbstractGroup
     }
 
     /// <inheritdoc/>
-    public override bool GetSelectable(
+    public override bool GetSelectables(
         NavigationDirection direction,
-        [MaybeNullWhen(false)] out Selectable selectable
+        [MaybeNullWhen(false)] out IEnumerable<Selectable> selectables
     )
     {
-        var navigable = direction switch
+        var navigables = direction switch
         {
-            // Last element.
-            NavigationDirection.Up => AllEntities()
-                .Where(e => e.VisibleSelf)
-                .OfType<INavigable>()
-                .LastOrDefault(),
-            // Rightmost element.
-            NavigationDirection.Left => GetColumns()
-                .SelectMany(col => col.WhereNonNull(e => e.VisibleSelf).OfType<INavigable>())
-                .LastOrDefault(),
-            // Leftmost element.
-            NavigationDirection.Right => GetColumns()
-                .SelectMany(col => col.WhereNonNull(e => e.VisibleSelf).OfType<INavigable>())
-                .FirstOrDefault(),
-            // First element.
-            NavigationDirection.Down => AllEntities()
-                .Where(e => e.VisibleSelf)
-                .OfType<INavigable>()
-                .FirstOrDefault(),
+            // Bottom row.
+            NavigationDirection.Up => GetNavigables(NavigationDirection.Down),
+            // Rightmost element of every row.
+            NavigationDirection.Left => GetNavigables(NavigationDirection.Right),
+            // Leftmost element of every row.
+            NavigationDirection.Right => GetNavigables(NavigationDirection.Left),
+            // Top row.
+            NavigationDirection.Down => GetNavigables(NavigationDirection.Up),
             _ => throw new ArgumentException($"{direction}"),
         };
 
-        selectable = default;
-        return navigable != null && navigable.GetSelectable(direction, out selectable);
+        selectables =
+            navigables?.SelectMany(x => x.GetSelectables(direction, out var s) ? s : []) ?? [];
+        return navigables != null && selectables.Any();
     }
 
     /// <inheritdoc/>
@@ -216,7 +207,7 @@ public class GridGroup(int columns) : AbstractGroup
                     INavigable?[] row,
                     NavigationDirection dir,
                     int column,
-                    [MaybeNullWhen(false)] out Selectable target
+                    [MaybeNullWhen(false)] out IEnumerable<Selectable> targets
                 )
                 {
                     int offset = 0;
@@ -235,12 +226,12 @@ public class GridGroup(int columns) : AbstractGroup
                         if (
                             idx >= 0
                             && idx < row.Length
-                            && (row[idx]?.GetSelectable(dir, out target) ?? false)
+                            && (row[idx]?.GetSelectables(dir, out targets) ?? false)
                         )
                             return true;
                     }
 
-                    target = default;
+                    targets = default;
                     return false;
                 }
 

--- a/Silksong.ModMenu/Elements/GridGroup.cs
+++ b/Silksong.ModMenu/Elements/GridGroup.cs
@@ -172,9 +172,8 @@ public class GridGroup(int columns) : AbstractGroup
             _ => throw new ArgumentException($"{direction}"),
         };
 
-        selectables =
-            navigables?.SelectMany(x => x.GetSelectables(direction, out var s) ? s : []) ?? [];
-        return navigables != null && selectables.Any();
+        selectables = navigables.SelectMany(x => x.GetSelectables(direction, out var s) ? s : []);
+        return selectables.Any();
     }
 
     /// <inheritdoc/>
@@ -245,12 +244,12 @@ public class GridGroup(int columns) : AbstractGroup
                         prevRow[i] != null
                         && ClosestColumn(nextRow, NavigationDirection.Down, i, out var s)
                     )
-                        prevRow[i]!.SetNeighborDown(s);
+                        prevRow[i]!.SetNeighborsDown(s);
                     if (
                         nextRow[i] != null
                         && ClosestColumn(prevRow, NavigationDirection.Up, i, out s)
                     )
-                        nextRow[i]!.SetNeighborUp(s);
+                        nextRow[i]!.SetNeighborsUp(s);
                 }
             }
             prevRow = nextRow;

--- a/Silksong.ModMenu/Elements/GridGroup.cs
+++ b/Silksong.ModMenu/Elements/GridGroup.cs
@@ -157,14 +157,18 @@ public class GridGroup(int columns) : AbstractGroup
     {
         var navigables = direction switch
         {
-            // Bottom row.
-            NavigationDirection.Up => GetNavigables(NavigationDirection.Down),
+            // Bottommost element of every column.
+            NavigationDirection.Up => GetColumns()
+                .Select(x => (INavigable?)x.LastOrDefault(e => e is INavigable && e.VisibleSelf))
+                .WhereNonNull(),
             // Rightmost element of every row.
             NavigationDirection.Left => GetNavigables(NavigationDirection.Right),
             // Leftmost element of every row.
             NavigationDirection.Right => GetNavigables(NavigationDirection.Left),
-            // Top row.
-            NavigationDirection.Down => GetNavigables(NavigationDirection.Up),
+            // Topmost element of every column.
+            NavigationDirection.Down => GetColumns()
+                .Select(x => (INavigable?)x.FirstOrDefault(e => e is INavigable && e.VisibleSelf))
+                .WhereNonNull(),
             _ => throw new ArgumentException($"{direction}"),
         };
 

--- a/Silksong.ModMenu/Elements/INavigable.cs
+++ b/Silksong.ModMenu/Elements/INavigable.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using UnityEngine.UI;
 
 namespace Silksong.ModMenu.Elements;
@@ -14,10 +16,10 @@ public interface INavigable
     void ClearNeighbors();
 
     /// <summary>
-    /// Set the directional neighbor of this entity.
+    /// Set the directional neighbor of this entity to one of the given choices.
     /// </summary>
     /// <returns>False if this entity has no navigation to connect.</returns>
-    void SetNeighbor(NavigationDirection direction, Selectable selectable);
+    void SetNeighbor(NavigationDirection direction, IEnumerable<Selectable> selectables);
 
     /// <summary>
     /// Unset the given directional neighbor of this entity.
@@ -25,14 +27,14 @@ public interface INavigable
     void ClearNeighbor(NavigationDirection direction);
 
     /// <summary>
-    /// Get the Selectable to target if navigating to this element along 'direction'.
+    /// Get a set of choices for the Selectable to target if navigating to this element along 'direction'.
     ///
     /// In other words, typical usage would entail:
-    ///   if (foo.GetSelectable(dir, out var selectable))
-    ///       bar.SetNeighbor(dir, selectable);
+    ///   if (foo.GetSelectables(dir, out var selectables))
+    ///       bar.SetNeighbor(dir, selectables);
     /// </summary>
-    bool GetSelectable(
+    bool GetSelectables(
         NavigationDirection direction,
-        [MaybeNullWhen(false)] out Selectable selectable
+        [MaybeNullWhen(false)] out IEnumerable<Selectable> selectables
     );
 }

--- a/Silksong.ModMenu/Elements/INavigable.cs
+++ b/Silksong.ModMenu/Elements/INavigable.cs
@@ -16,22 +16,22 @@ public interface INavigable
     void ClearNeighbors();
 
     /// <summary>
-    /// Set the directional neighbor of this entity to one of the given choices.
+    /// Set the directional neighbors of this entity to one or more of the given choices.
     /// </summary>
     /// <returns>False if this entity has no navigation to connect.</returns>
-    void SetNeighbor(NavigationDirection direction, IEnumerable<Selectable> selectables);
+    void SetNeighbors(NavigationDirection direction, IEnumerable<Selectable> selectables);
 
     /// <summary>
     /// Unset the given directional neighbor of this entity.
     /// </summary>
-    void ClearNeighbor(NavigationDirection direction);
+    void ClearNeighbors(NavigationDirection direction);
 
     /// <summary>
-    /// Get a set of choices for the Selectable to target if navigating to this element along 'direction'.
+    /// Get a set of choices for the Selectables to target if navigating to this element along 'direction'.
     ///
     /// In other words, typical usage would entail:
     ///   if (foo.GetSelectables(dir, out var selectables))
-    ///       bar.SetNeighbor(dir, selectables);
+    ///       bar.SetNeighbors(dir, selectables);
     /// </summary>
     bool GetSelectables(
         NavigationDirection direction,

--- a/Silksong.ModMenu/Elements/INavigableExtensions.cs
+++ b/Silksong.ModMenu/Elements/INavigableExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using UnityEngine.UI;
 
 namespace Silksong.ModMenu.Elements;
@@ -17,13 +18,22 @@ public static class INavigableExtensions
         /// Set the upwards neighbor of this navigable.
         /// </summary>
         public void SetNeighborUp(Selectable selectable) =>
-            self.SetNeighbor(NavigationDirection.Up, selectable);
+            self.SetNeighbor(NavigationDirection.Up, [selectable]);
+
+        /// <summary>
+        /// Set the upwards neighbor of this navigable to one of the given options.
+        /// </summary>
+        public void SetNeighborUp(IEnumerable<Selectable> selectables) =>
+            self.SetNeighbor(NavigationDirection.Up, selectables);
 
         /// <summary>
         /// Set the upwards neighbor of this navigable.
         /// </summary>
-        public void SetNeighborUp(SelectableElement selectableElement) =>
-            self.SetNeighborUp(selectableElement.SelectableComponent);
+        public void SetNeighborUp(SelectableElement selectableElement)
+        {
+            if (selectableElement.GetSelectables(NavigationDirection.Up, out var selectables))
+                self.SetNeighborDown(selectables);
+        }
 
         /// <summary>
         /// Declare that this navigable has no upwards neighbor.
@@ -31,22 +41,32 @@ public static class INavigableExtensions
         public void ClearNeighborUp() => self.ClearNeighbor(NavigationDirection.Up);
 
         /// <summary>
-        /// Get the most eligible selectable within this navigable when navigating upwards into it.
+        /// Get the most eligible selectables within this navigable when navigating upwards into it.
         /// </summary>
-        public bool GetNeighborUp([MaybeNullWhen(false)] out Selectable selectable) =>
-            self.GetSelectable(NavigationDirection.Up, out selectable);
+        public bool GetNeighborsUp(
+            [MaybeNullWhen(false)] out IEnumerable<Selectable> selectables
+        ) => self.GetSelectables(NavigationDirection.Up, out selectables);
 
         /// <summary>
         /// Set the leftwards neighbor of this navigable.
         /// </summary>
         public void SetNeighborLeft(Selectable selectable) =>
-            self.SetNeighbor(NavigationDirection.Left, selectable);
+            self.SetNeighbor(NavigationDirection.Left, [selectable]);
+
+        /// <summary>
+        /// Set the leftwards neighbor of this navigable to one of the given options.
+        /// </summary>
+        public void SetNeighborLeft(IEnumerable<Selectable> selectables) =>
+            self.SetNeighbor(NavigationDirection.Left, selectables);
 
         /// <summary>
         /// Set the leftwards neighbor of this navigable.
         /// </summary>
-        public void SetNeighborLeft(SelectableElement selectableElement) =>
-            self.SetNeighborLeft(selectableElement.SelectableComponent);
+        public void SetNeighborLeft(SelectableElement selectableElement)
+        {
+            if (selectableElement.GetSelectables(NavigationDirection.Left, out var selectables))
+                self.SetNeighborDown(selectables);
+        }
 
         /// <summary>
         /// Declare that this navigable has no upwards neighbor.
@@ -54,28 +74,39 @@ public static class INavigableExtensions
         public void ClearNeighborLeft() => self.ClearNeighbor(NavigationDirection.Left);
 
         /// <summary>
-        /// Get the most eligible selectable within this navigable when navigating leftwards into it.
+        /// Get the most eligible selectables within this navigable when navigating leftwards into it.
         /// </summary>
-        public bool GetNeighborLeft([MaybeNullWhen(false)] out Selectable selectable) =>
-            self.GetSelectable(NavigationDirection.Left, out selectable);
+        public bool GetNeighborsLeft(
+            [MaybeNullWhen(false)] out IEnumerable<Selectable> selectable
+        ) => self.GetSelectables(NavigationDirection.Left, out selectable);
 
         /// <summary>
         /// Set the rightwards neighbor of this navigable.
         /// </summary>
         public void SetNeighborRight(Selectable selectable) =>
-            self.SetNeighbor(NavigationDirection.Right, selectable);
+            self.SetNeighbor(NavigationDirection.Right, [selectable]);
+
+        /// <summary>
+        /// Set the rightwards neighbor of this navigable to one of the given options.
+        /// </summary>
+        public void SetNeighborRight(IEnumerable<Selectable> selectables) =>
+            self.SetNeighbor(NavigationDirection.Right, selectables);
 
         /// <summary>
         /// Set the rightwards neighbor of this navigable.
         /// </summary>
-        public void SetNeighborRight(SelectableElement selectableElement) =>
-            self.SetNeighborRight(selectableElement.SelectableComponent);
+        public void SetNeighborRight(SelectableElement selectableElement)
+        {
+            if (selectableElement.GetSelectables(NavigationDirection.Right, out var selectables))
+                self.SetNeighborDown(selectables);
+        }
 
         /// <summary>
-        /// Get the most eligible selectable within this navigable when navigating rightwards into it.
+        /// Get the most eligible selectables within this navigable when navigating rightwards into it.
         /// </summary>
-        public bool GetNeighborRight([MaybeNullWhen(false)] out Selectable selectable) =>
-            self.GetSelectable(NavigationDirection.Right, out selectable);
+        public bool GetNeighborsRight(
+            [MaybeNullWhen(false)] out IEnumerable<Selectable> selectables
+        ) => self.GetSelectables(NavigationDirection.Right, out selectables);
 
         /// <summary>
         /// Declare that this navigable has no upwards neighbor.
@@ -86,13 +117,22 @@ public static class INavigableExtensions
         /// Set the downwards neighbor of this navigable.
         /// </summary>
         public void SetNeighborDown(Selectable selectable) =>
-            self.SetNeighbor(NavigationDirection.Down, selectable);
+            self.SetNeighbor(NavigationDirection.Down, [selectable]);
+
+        /// <summary>
+        /// Set the downwards neighbor of this navigable to one of the given options.
+        /// </summary>
+        public void SetNeighborDown(IEnumerable<Selectable> selectables) =>
+            self.SetNeighbor(NavigationDirection.Down, selectables);
 
         /// <summary>
         /// Set the downwards neighbor of this navigable.
         /// </summary>
-        public void SetNeighborDown(SelectableElement selectableElement) =>
-            self.SetNeighborDown(selectableElement.SelectableComponent);
+        public void SetNeighborDown(SelectableElement selectableElement)
+        {
+            if (selectableElement.GetSelectables(NavigationDirection.Down, out var selectables))
+                self.SetNeighborDown(selectables);
+        }
 
         /// <summary>
         /// Declare that this navigable has no upwards neighbor.
@@ -100,19 +140,20 @@ public static class INavigableExtensions
         public void ClearNeighborDown() => self.ClearNeighbor(NavigationDirection.Down);
 
         /// <summary>
-        /// Get the most eligible selectable within this navigable when navigating downwards into it.
+        /// Get the most eligible selectables within this navigable when navigating downwards into it.
         /// </summary>
-        public bool GetNeighborDown([MaybeNullWhen(false)] out Selectable selectable) =>
-            self.GetSelectable(NavigationDirection.Down, out selectable);
+        public bool GetNeighborsDown(
+            [MaybeNullWhen(false)] out IEnumerable<Selectable> selectables
+        ) => self.GetSelectables(NavigationDirection.Down, out selectables);
 
         /// <summary>
         /// Symmetrically connect two INavigables.
         /// </summary>
         public void ConnectSymmetric(INavigable dest, NavigationDirection direction)
         {
-            if (dest.GetSelectable(direction, out var s))
+            if (dest.GetSelectables(direction, out var s))
                 self.SetNeighbor(direction, s);
-            if (self.GetSelectable(direction.Opposite(), out s))
+            if (self.GetSelectables(direction.Opposite(), out s))
                 dest.SetNeighbor(direction.Opposite(), s);
         }
     }

--- a/Silksong.ModMenu/Elements/INavigableExtensions.cs
+++ b/Silksong.ModMenu/Elements/INavigableExtensions.cs
@@ -15,30 +15,30 @@ public static class INavigableExtensions
     extension(INavigable self)
     {
         /// <summary>
-        /// Set the upwards neighbor of this navigable.
+        /// Set the upwards neighbors of this navigable.
         /// </summary>
-        public void SetNeighborUp(Selectable selectable) =>
-            self.SetNeighbor(NavigationDirection.Up, [selectable]);
+        public void SetNeighborsUp(Selectable selectable) =>
+            self.SetNeighbors(NavigationDirection.Up, [selectable]);
 
         /// <summary>
-        /// Set the upwards neighbor of this navigable to one of the given options.
+        /// Set the upwards neighbors of this navigable to one or more of the given options.
         /// </summary>
-        public void SetNeighborUp(IEnumerable<Selectable> selectables) =>
-            self.SetNeighbor(NavigationDirection.Up, selectables);
+        public void SetNeighborsUp(IEnumerable<Selectable> selectables) =>
+            self.SetNeighbors(NavigationDirection.Up, selectables);
 
         /// <summary>
-        /// Set the upwards neighbor of this navigable.
+        /// Set the upwards neighbors of this navigable.
         /// </summary>
-        public void SetNeighborUp(SelectableElement selectableElement)
+        public void SetNeighborsUp(SelectableElement selectableElement)
         {
             if (selectableElement.GetSelectables(NavigationDirection.Up, out var selectables))
-                self.SetNeighborDown(selectables);
+                self.SetNeighborsUp(selectables);
         }
 
         /// <summary>
-        /// Declare that this navigable has no upwards neighbor.
+        /// Declare that this navigable has no upwards neighbors.
         /// </summary>
-        public void ClearNeighborUp() => self.ClearNeighbor(NavigationDirection.Up);
+        public void ClearNeighborsUp() => self.ClearNeighbors(NavigationDirection.Up);
 
         /// <summary>
         /// Get the most eligible selectables within this navigable when navigating upwards into it.
@@ -48,57 +48,57 @@ public static class INavigableExtensions
         ) => self.GetSelectables(NavigationDirection.Up, out selectables);
 
         /// <summary>
-        /// Set the leftwards neighbor of this navigable.
+        /// Set the leftwards neighbors of this navigable.
         /// </summary>
-        public void SetNeighborLeft(Selectable selectable) =>
-            self.SetNeighbor(NavigationDirection.Left, [selectable]);
+        public void SetNeighborsLeft(Selectable selectable) =>
+            self.SetNeighbors(NavigationDirection.Left, [selectable]);
 
         /// <summary>
-        /// Set the leftwards neighbor of this navigable to one of the given options.
+        /// Set the leftwards neighbors of this navigable to one or more of the given options.
         /// </summary>
-        public void SetNeighborLeft(IEnumerable<Selectable> selectables) =>
-            self.SetNeighbor(NavigationDirection.Left, selectables);
+        public void SetNeighborsLeft(IEnumerable<Selectable> selectables) =>
+            self.SetNeighbors(NavigationDirection.Left, selectables);
 
         /// <summary>
-        /// Set the leftwards neighbor of this navigable.
+        /// Set the leftwards neighbors of this navigable.
         /// </summary>
-        public void SetNeighborLeft(SelectableElement selectableElement)
+        public void SetNeighborsLeft(SelectableElement selectableElement)
         {
             if (selectableElement.GetSelectables(NavigationDirection.Left, out var selectables))
-                self.SetNeighborDown(selectables);
+                self.SetNeighborsLeft(selectables);
         }
 
         /// <summary>
-        /// Declare that this navigable has no upwards neighbor.
+        /// Declare that this navigable has no upwards neighbors.
         /// </summary>
-        public void ClearNeighborLeft() => self.ClearNeighbor(NavigationDirection.Left);
+        public void ClearNeighborsLeft() => self.ClearNeighbors(NavigationDirection.Left);
 
         /// <summary>
         /// Get the most eligible selectables within this navigable when navigating leftwards into it.
         /// </summary>
         public bool GetNeighborsLeft(
-            [MaybeNullWhen(false)] out IEnumerable<Selectable> selectable
-        ) => self.GetSelectables(NavigationDirection.Left, out selectable);
+            [MaybeNullWhen(false)] out IEnumerable<Selectable> selectables
+        ) => self.GetSelectables(NavigationDirection.Left, out selectables);
 
         /// <summary>
-        /// Set the rightwards neighbor of this navigable.
+        /// Set the rightwards neighbors of this navigable.
         /// </summary>
-        public void SetNeighborRight(Selectable selectable) =>
-            self.SetNeighbor(NavigationDirection.Right, [selectable]);
+        public void SetNeighborsRight(Selectable selectable) =>
+            self.SetNeighbors(NavigationDirection.Right, [selectable]);
 
         /// <summary>
-        /// Set the rightwards neighbor of this navigable to one of the given options.
+        /// Set the rightwards neighbors of this navigable to one or more of the given options.
         /// </summary>
-        public void SetNeighborRight(IEnumerable<Selectable> selectables) =>
-            self.SetNeighbor(NavigationDirection.Right, selectables);
+        public void SetNeighborsRight(IEnumerable<Selectable> selectables) =>
+            self.SetNeighbors(NavigationDirection.Right, selectables);
 
         /// <summary>
-        /// Set the rightwards neighbor of this navigable.
+        /// Set the rightwards neighbors of this navigable.
         /// </summary>
-        public void SetNeighborRight(SelectableElement selectableElement)
+        public void SetNeighborsRight(SelectableElement selectableElement)
         {
             if (selectableElement.GetSelectables(NavigationDirection.Right, out var selectables))
-                self.SetNeighborDown(selectables);
+                self.SetNeighborsRight(selectables);
         }
 
         /// <summary>
@@ -109,35 +109,35 @@ public static class INavigableExtensions
         ) => self.GetSelectables(NavigationDirection.Right, out selectables);
 
         /// <summary>
-        /// Declare that this navigable has no upwards neighbor.
+        /// Declare that this navigable has no upwards neighbors.
         /// </summary>
-        public void ClearNeighborRight() => self.ClearNeighbor(NavigationDirection.Right);
+        public void ClearNeighborsRight() => self.ClearNeighbors(NavigationDirection.Right);
 
         /// <summary>
-        /// Set the downwards neighbor of this navigable.
+        /// Set the downwards neighbors of this navigable.
         /// </summary>
         public void SetNeighborDown(Selectable selectable) =>
-            self.SetNeighbor(NavigationDirection.Down, [selectable]);
+            self.SetNeighbors(NavigationDirection.Down, [selectable]);
 
         /// <summary>
-        /// Set the downwards neighbor of this navigable to one of the given options.
+        /// Set the downwards neighbors of this navigable to one or more of the given options.
         /// </summary>
-        public void SetNeighborDown(IEnumerable<Selectable> selectables) =>
-            self.SetNeighbor(NavigationDirection.Down, selectables);
+        public void SetNeighborsDown(IEnumerable<Selectable> selectables) =>
+            self.SetNeighbors(NavigationDirection.Down, selectables);
 
         /// <summary>
-        /// Set the downwards neighbor of this navigable.
+        /// Set the downwards neighbors of this navigable.
         /// </summary>
-        public void SetNeighborDown(SelectableElement selectableElement)
+        public void SetNeighborsDown(SelectableElement selectableElement)
         {
             if (selectableElement.GetSelectables(NavigationDirection.Down, out var selectables))
-                self.SetNeighborDown(selectables);
+                self.SetNeighborsDown(selectables);
         }
 
         /// <summary>
-        /// Declare that this navigable has no upwards neighbor.
+        /// Declare that this navigable has no upwards neighbors.
         /// </summary>
-        public void ClearNeighborDown() => self.ClearNeighbor(NavigationDirection.Down);
+        public void ClearNeighborsDown() => self.ClearNeighbors(NavigationDirection.Down);
 
         /// <summary>
         /// Get the most eligible selectables within this navigable when navigating downwards into it.
@@ -152,9 +152,9 @@ public static class INavigableExtensions
         public void ConnectSymmetric(INavigable dest, NavigationDirection direction)
         {
             if (dest.GetSelectables(direction, out var s))
-                self.SetNeighbor(direction, s);
+                self.SetNeighbors(direction, s);
             if (self.GetSelectables(direction.Opposite(), out s))
-                dest.SetNeighbor(direction.Opposite(), s);
+                dest.SetNeighbors(direction.Opposite(), s);
         }
     }
 }

--- a/Silksong.ModMenu/Elements/ScrollingPane.cs
+++ b/Silksong.ModMenu/Elements/ScrollingPane.cs
@@ -288,20 +288,20 @@ public class ScrollingPane : MenuDisposable, INavigableMenuEntity
     public void ClearNeighbors() => Content?.ClearNeighbors();
 
     /// <inheritdoc/>
-    public void SetNeighbor(NavigationDirection direction, Selectable selectable) =>
-        Content?.SetNeighbor(direction, selectable);
+    public void SetNeighbor(NavigationDirection direction, IEnumerable<Selectable> selectables) =>
+        Content?.SetNeighbor(direction, selectables);
 
     /// <inheritdoc/>
     public void ClearNeighbor(NavigationDirection direction) => Content?.ClearNeighbor(direction);
 
     /// <inheritdoc/>
-    public bool GetSelectable(
+    public bool GetSelectables(
         NavigationDirection direction,
-        [MaybeNullWhen(false)] out Selectable selectable
+        [MaybeNullWhen(false)] out IEnumerable<Selectable> selectables
     )
     {
-        selectable = default;
-        return Content?.GetSelectable(direction, out selectable) ?? false;
+        selectables = default;
+        return Content?.GetSelectables(direction, out selectables) ?? false;
     }
 
     #endregion

--- a/Silksong.ModMenu/Elements/ScrollingPane.cs
+++ b/Silksong.ModMenu/Elements/ScrollingPane.cs
@@ -288,11 +288,11 @@ public class ScrollingPane : MenuDisposable, INavigableMenuEntity
     public void ClearNeighbors() => Content?.ClearNeighbors();
 
     /// <inheritdoc/>
-    public void SetNeighbor(NavigationDirection direction, IEnumerable<Selectable> selectables) =>
-        Content?.SetNeighbor(direction, selectables);
+    public void SetNeighbors(NavigationDirection direction, IEnumerable<Selectable> selectables) =>
+        Content?.SetNeighbors(direction, selectables);
 
     /// <inheritdoc/>
-    public void ClearNeighbor(NavigationDirection direction) => Content?.ClearNeighbor(direction);
+    public void ClearNeighbors(NavigationDirection direction) => Content?.ClearNeighbors(direction);
 
     /// <inheritdoc/>
     public bool GetSelectables(

--- a/Silksong.ModMenu/Elements/SelectableElement.cs
+++ b/Silksong.ModMenu/Elements/SelectableElement.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Silksong.ModMenu.Internal;
 using Silksong.ModMenu.Util;
@@ -75,16 +76,16 @@ public abstract class SelectableElement : MenuElement, INavigableMenuEntity
         new SelectableWrapper(SelectableComponent).ClearNeighbor(direction);
 
     /// <inheritdoc/>
-    public void SetNeighbor(NavigationDirection direction, Selectable selectable) =>
-        new SelectableWrapper(SelectableComponent).SetNeighbor(direction, selectable);
+    public void SetNeighbor(NavigationDirection direction, IEnumerable<Selectable> selectables) =>
+        new SelectableWrapper(SelectableComponent).SetNeighbor(direction, selectables);
 
     /// <inheritdoc/>
-    public bool GetSelectable(
+    public bool GetSelectables(
         NavigationDirection direction,
-        [MaybeNullWhen(false)] out Selectable selectable
+        [MaybeNullWhen(false)] out IEnumerable<Selectable> selectables
     )
     {
-        selectable = SelectableComponent;
+        selectables = [SelectableComponent];
         return true;
     }
 

--- a/Silksong.ModMenu/Elements/SelectableElement.cs
+++ b/Silksong.ModMenu/Elements/SelectableElement.cs
@@ -72,12 +72,12 @@ public abstract class SelectableElement : MenuElement, INavigableMenuEntity
     public void ClearNeighbors() => new SelectableWrapper(SelectableComponent).ClearNeighbors();
 
     /// <inheritdoc/>
-    public void ClearNeighbor(NavigationDirection direction) =>
-        new SelectableWrapper(SelectableComponent).ClearNeighbor(direction);
+    public void ClearNeighbors(NavigationDirection direction) =>
+        new SelectableWrapper(SelectableComponent).ClearNeighbors(direction);
 
     /// <inheritdoc/>
-    public void SetNeighbor(NavigationDirection direction, IEnumerable<Selectable> selectables) =>
-        new SelectableWrapper(SelectableComponent).SetNeighbor(direction, selectables);
+    public void SetNeighbors(NavigationDirection direction, IEnumerable<Selectable> selectables) =>
+        new SelectableWrapper(SelectableComponent).SetNeighbors(direction, selectables);
 
     /// <inheritdoc/>
     public bool GetSelectables(

--- a/Silksong.ModMenu/Elements/TextButton.cs
+++ b/Silksong.ModMenu/Elements/TextButton.cs
@@ -20,7 +20,6 @@ public class TextButton : SelectableElement
         : base(MenuPrefabs.Get().NewTextButtonContainer(out var menuButton), menuButton)
     {
         Container.name = text.Text;
-        SelectableComponent.name = text.Canonical;
 
         MenuButton = menuButton;
         MenuButton

--- a/Silksong.ModMenu/Elements/TextButton.cs
+++ b/Silksong.ModMenu/Elements/TextButton.cs
@@ -20,6 +20,7 @@ public class TextButton : SelectableElement
         : base(MenuPrefabs.Get().NewTextButtonContainer(out var menuButton), menuButton)
     {
         Container.name = text.Text;
+        SelectableComponent.name = text.Canonical;
 
         MenuButton = menuButton;
         MenuButton

--- a/Silksong.ModMenu/Elements/VerticalGroup.cs
+++ b/Silksong.ModMenu/Elements/VerticalGroup.cs
@@ -89,33 +89,31 @@ public class VerticalGroup : AbstractGroup
     }
 
     /// <inheritdoc/>
-    public override bool GetSelectable(
+    public override bool GetSelectables(
         NavigationDirection direction,
-        [MaybeNullWhen(false)] out Selectable selectable
+        [MaybeNullWhen(false)] out IEnumerable<Selectable> selectables
     )
     {
         switch (direction)
         {
             case NavigationDirection.Left:
             case NavigationDirection.Right:
-                selectable = NonHiddenEntities()
-                    .MedianOutwards()
+                selectables = NonHiddenEntities()
                     .OfType<INavigable>()
-                    .Select(n => n.GetSelectable(direction, out var s) ? s : null)
-                    .FirstOrDefault();
-                return selectable != null;
+                    .SelectMany(n => n.GetSelectables(direction, out var s) ? s : null);
+                return selectables != null;
             case NavigationDirection.Up:
-                selectable = NonHiddenEntities()
+                selectables = NonHiddenEntities()
                     .OfType<INavigable>()
-                    .Select(n => n.GetSelectable(direction, out var s) ? s : null)
+                    .Select(n => n.GetSelectables(direction, out var s) ? s : null)
                     .LastOrDefault();
-                return selectable != null;
+                return selectables != null;
             case NavigationDirection.Down:
-                selectable = NonHiddenEntities()
+                selectables = NonHiddenEntities()
                     .OfType<INavigable>()
-                    .Select(n => n.GetSelectable(direction, out var s) ? s : null)
+                    .Select(n => n.GetSelectables(direction, out var s) ? s : null)
                     .FirstOrDefault();
-                return selectable != null;
+                return selectables != null;
             default:
                 throw direction.UnsupportedEnum();
         }

--- a/Silksong.ModMenu/Internal/SelectableWrapper.cs
+++ b/Silksong.ModMenu/Internal/SelectableWrapper.cs
@@ -23,7 +23,7 @@ internal class SelectableWrapper(Selectable selectable) : INavigable
             };
     }
 
-    public void ClearNeighbor(NavigationDirection direction) =>
+    public void ClearNeighbors(NavigationDirection direction) =>
         Nav = direction switch
         {
             NavigationDirection.Up => Nav with { selectOnUp = null },
@@ -44,7 +44,7 @@ internal class SelectableWrapper(Selectable selectable) : INavigable
         return true;
     }
 
-    public void SetNeighbor(NavigationDirection direction, IEnumerable<Selectable> selectables)
+    public void SetNeighbors(NavigationDirection direction, IEnumerable<Selectable> selectables)
     {
         if (!selectables.Any())
             throw new ArgumentException(
@@ -52,7 +52,7 @@ internal class SelectableWrapper(Selectable selectable) : INavigable
                 nameof(selectables)
             );
 
-        Vector2 position = selectable.transform.position;
+        Vector2 thisPosition = selectable.transform.position;
         Vector2 directionVector = direction switch
         {
             NavigationDirection.Up => Vector2.up,
@@ -65,20 +65,32 @@ internal class SelectableWrapper(Selectable selectable) : INavigable
         Selectable bestOption = selectables
             .Select(selectable =>
             {
-                Vector2 otherPos = selectable.transform.position,
-                    interAngle = otherPos - position;
-                float directionalAngle = Vector2.Angle(directionVector, interAngle);
+                Vector2 otherPosition = selectable.transform.position,
+                    angleBetweenSelectables = otherPosition - thisPosition;
+
+                float angleRelativeToDirection = Vector2.Angle(
+                        directionVector,
+                        angleBetweenSelectables
+                    ),
+                    angleRelativeToOpposite = Vector2.Angle(
+                        -directionVector,
+                        angleBetweenSelectables
+                    );
+
                 return (
                     selectable,
-                    directionalAngle,
-                    angle: Mathf.Min(directionalAngle, Vector2.Angle(-directionVector, interAngle)),
-                    position: otherPos
+                    angleRelativeToDirection,
+                    angleRelativeToAxis: Mathf.Min(
+                        angleRelativeToDirection,
+                        angleRelativeToOpposite
+                    ),
+                    position: otherPosition
                 );
             })
-            // Rough shallowness of the angle between selectables, then favour selectables on the correct side of this one
-            .OrderBy(x => (int)Mathf.RoundToMultipleOf(x.angle, 20))
-            .ThenBy(x => (int)Mathf.RoundToMultipleOf(x.directionalAngle, 90))
-            .ThenBy(x => Vector2.Distance(position, x.position))
+            // Favour selectables on the correct side of this one, narrow down by how well aligned they are with the current selectable
+            .OrderBy(other => (int)Mathf.RoundToMultipleOf(other.angleRelativeToDirection, 180))
+            .ThenBy(other => (int)Mathf.RoundToMultipleOf(other.angleRelativeToAxis, 20))
+            .ThenBy(other => Vector2.Distance(thisPosition, other.position))
             .First()
             .selectable;
 

--- a/Silksong.ModMenu/Internal/SelectableWrapper.cs
+++ b/Silksong.ModMenu/Internal/SelectableWrapper.cs
@@ -1,5 +1,9 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Silksong.ModMenu.Elements;
+using UnityEngine;
 using UnityEngine.UI;
 
 namespace Silksong.ModMenu.Internal;
@@ -31,22 +35,60 @@ internal class SelectableWrapper(Selectable selectable) : INavigable
 
     public void ClearNeighbors() => Nav = new();
 
-    public bool GetSelectable(
+    public bool GetSelectables(
         NavigationDirection direction,
-        [MaybeNullWhen(false)] out Selectable selectable
+        [MaybeNullWhen(false)] out IEnumerable<Selectable> selectables
     )
     {
-        selectable = this.selectable;
+        selectables = [selectable];
         return true;
     }
 
-    public void SetNeighbor(NavigationDirection direction, Selectable selectable) =>
-        Nav = direction switch
+    public void SetNeighbor(NavigationDirection direction, IEnumerable<Selectable> selectables)
+    {
+        if (!selectables.Any())
+            throw new ArgumentException(
+                "At least one selectable is required.",
+                nameof(selectables)
+            );
+
+        Vector2 position = selectable.transform.position;
+        Vector2 directionVector = direction switch
         {
-            NavigationDirection.Up => Nav with { selectOnUp = selectable },
-            NavigationDirection.Left => Nav with { selectOnLeft = selectable },
-            NavigationDirection.Right => Nav with { selectOnRight = selectable },
-            NavigationDirection.Down => Nav with { selectOnDown = selectable },
+            NavigationDirection.Up => Vector2.up,
+            NavigationDirection.Left => Vector2.left,
+            NavigationDirection.Right => Vector2.right,
+            NavigationDirection.Down => Vector2.down,
             _ => throw direction.UnsupportedEnum(),
         };
+
+        Selectable bestOption = selectables
+            .Select(selectable =>
+            {
+                Vector2 otherPos = selectable.transform.position,
+                    interAngle = otherPos - position;
+                float directionalAngle = Vector2.Angle(directionVector, interAngle);
+                return (
+                    selectable,
+                    directionalAngle,
+                    angle: Mathf.Min(directionalAngle, Vector2.Angle(-directionVector, interAngle)),
+                    position: otherPos
+                );
+            })
+            // Rough shallowness of the angle between selectables, then favour selectables on the correct side of this one
+            .OrderBy(x => (int)Mathf.RoundToMultipleOf(x.angle, 20))
+            .ThenBy(x => (int)Mathf.RoundToMultipleOf(x.directionalAngle, 90))
+            .ThenBy(x => Vector2.Distance(position, x.position))
+            .First()
+            .selectable;
+
+        Nav = direction switch
+        {
+            NavigationDirection.Up => Nav with { selectOnUp = bestOption },
+            NavigationDirection.Left => Nav with { selectOnLeft = bestOption },
+            NavigationDirection.Right => Nav with { selectOnRight = bestOption },
+            NavigationDirection.Down => Nav with { selectOnDown = bestOption },
+            _ => throw direction.UnsupportedEnum(),
+        };
+    }
 }

--- a/Silksong.ModMenu/Screens/BasicMenuScreen.cs
+++ b/Silksong.ModMenu/Screens/BasicMenuScreen.cs
@@ -62,10 +62,10 @@ public class BasicMenuScreen : AbstractMenuScreen
         wrapper.ClearNeighbors();
 
         Content.SetNeighborDown(BackButton);
-        Content.SetNeighborUp(BackButton);
+        Content.SetNeighborsUp(BackButton);
         if (Content.GetNeighborsDown(out var selectables))
-            wrapper.SetNeighborDown(selectables);
+            wrapper.SetNeighborsDown(selectables);
         if (Content.GetNeighborsUp(out selectables))
-            wrapper.SetNeighborUp(selectables);
+            wrapper.SetNeighborsUp(selectables);
     }
 }

--- a/Silksong.ModMenu/Screens/BasicMenuScreen.cs
+++ b/Silksong.ModMenu/Screens/BasicMenuScreen.cs
@@ -63,9 +63,9 @@ public class BasicMenuScreen : AbstractMenuScreen
 
         Content.SetNeighborDown(BackButton);
         Content.SetNeighborUp(BackButton);
-        if (Content.GetNeighborDown(out var selectable))
-            wrapper.SetNeighborDown(selectable);
-        if (Content.GetNeighborUp(out selectable))
-            wrapper.SetNeighborUp(selectable);
+        if (Content.GetNeighborsDown(out var selectables))
+            wrapper.SetNeighborDown(selectables);
+        if (Content.GetNeighborsUp(out selectables))
+            wrapper.SetNeighborUp(selectables);
     }
 }

--- a/Silksong.ModMenu/Screens/PaginatedMenuScreen.cs
+++ b/Silksong.ModMenu/Screens/PaginatedMenuScreen.cs
@@ -141,9 +141,9 @@ public class PaginatedMenuScreen : AbstractMenuScreen
         foreach (var (top, bot) in column.CircularPairs())
         {
             if (top.GetNeighborsUp(out var s))
-                bot.SetNeighborUp(s);
+                bot.SetNeighborsUp(s);
             if (bot.GetNeighborsDown(out s))
-                top.SetNeighborDown(s);
+                top.SetNeighborsDown(s);
         }
     }
 }

--- a/Silksong.ModMenu/Screens/PaginatedMenuScreen.cs
+++ b/Silksong.ModMenu/Screens/PaginatedMenuScreen.cs
@@ -140,9 +140,9 @@ public class PaginatedMenuScreen : AbstractMenuScreen
             s.ClearNeighbors();
         foreach (var (top, bot) in column.CircularPairs())
         {
-            if (top.GetNeighborUp(out var s))
+            if (top.GetNeighborsUp(out var s))
                 bot.SetNeighborUp(s);
-            if (bot.GetNeighborDown(out s))
+            if (bot.GetNeighborsDown(out s))
                 top.SetNeighborDown(s);
         }
     }

--- a/Silksong.ModMenuTesting/Tests/ScrollingPaneTests.cs
+++ b/Silksong.ModMenuTesting/Tests/ScrollingPaneTests.cs
@@ -32,33 +32,33 @@ internal class ScrollingPaneTests : ModMenuTest
     /// </summary>
     static GridGroup ScrollPaneSiblings()
     {
-        VerticalGroup innerContentOne = new(),
-            innerContentTwo = new();
+        VerticalGroup contentOne = new() { VerticalSpacing = SpacingConstants.VSPACE_LARGE },
+            contentTwo = new() { VerticalSpacing = SpacingConstants.VSPACE_MEDIUM },
+            contentFour = new() { VerticalSpacing = SpacingConstants.VSPACE_SMALL };
 
-        for (int i = 1; i <= 15; i++)
+        GridGroup contentThree = new(2) { HorizontalSpacing = 240 };
+
+        for (int i = 1; i <= 6; i++)
         {
-            innerContentOne.Add(new TextButton($"Hollow {i}"));
-            innerContentTwo.Add(new TextButton($"Knight {i}"));
+            contentOne.Add(new TextButton($"Hollow {i}"));
+            contentFour.Add(new TextButton($"Silksong {i}"));
+        }
+        for (int i = 1; i <= 12; i++)
+        {
+            contentTwo.Add(new TextButton($"Knight {i}"));
+            contentThree.Add(new TextButton($"Yay {i}"));
         }
 
-        ScrollingPane innerScrollOne =
-                new(innerContentOne)
-                {
-                    ViewportSize = new Vector2(500, 875),
-                    SmoothScrollTime = 0.5f,
-                },
-            innerScrollTwo =
-                new(innerContentTwo)
-                {
-                    ViewportSize = new Vector2(500, 875),
-                    SmoothScrollTime = 0.5f,
-                };
+        ScrollingPane scrollOne = new(contentOne) { ViewportSize = new Vector2(500, 675) },
+            scrollTwo = new(contentTwo) { ViewportSize = new Vector2(500, 675) };
 
-        GridGroup outerContent = new(2) { HorizontalSpacing = 600 };
-        outerContent.Add(innerScrollOne);
-        outerContent.Add(innerScrollTwo);
+        GridGroup outer = new(4) { HorizontalSpacing = SpacingConstants.HSPACE_SMALL };
+        outer.Add(scrollOne);
+        outer.Add(scrollTwo);
+        outer.Add(contentThree);
+        outer.Add(contentFour);
 
-        return outerContent;
+        return outer;
     }
 
     /// <summary>


### PR DESCRIPTION
### Summary of Changes

This PR closes #75 by:
* Giving `INavigable`s the option of providing a choice of multiple selectables for each incoming navigation direction.
* Changing `SelectableWrapper` to pick from these options based on distance and how shallow the angle is between selectables in the given axis of travel.
* Changing `VerticalGroup` to offer a choice of any of its selectables when being navigated to from the left or right
* Changing `GridGroup` to offer a choice of its leftmost/topmost/etc selectables from each row/column when being navigated to from each direction.

The "Scrolling Pane Tests" menu has multiple Grid and Vertical groups laid out beside each other and nested in various ways so it makes a decent testing ground for the new behaviour.

Some methods in `INavigable` and `INavigableExtensions` have had their names and parameter types changed so this does have some breaking changes; it might affect mods that set up navigation between elements manually with a FreeGroup.

### Checklist

* No change is too small for a release, so pick one:
  * [x] I have updated the package version following semantic versioning
  * [ ] There is another change actively WIP that will update the version
  * [ ] This PR does not update user-facing code/config
  * [ ] I'm not sure how to set the version and would like the reviewer's help