### PR TITLE
Allow ModMenuIgnore on properties

### DIFF
--- a/Silksong.ModMenu/Directory.Build.props
+++ b/Silksong.ModMenu/Directory.Build.props
@@ -11,6 +11,6 @@
     It should follow the format major.minor.patch (semantic versioning). If you publish your mod
     as a library to NuGet, this version will also be used as the package version.
     -->
-    <Version>0.7.1</Version>
+    <Version>0.7.2</Version>
   </PropertyGroup>
 </Project>

--- a/Silksong.ModMenu/Models/Attributes.cs
+++ b/Silksong.ModMenu/Models/Attributes.cs
@@ -22,7 +22,10 @@ public class ModMenuNameAttribute(string customName) : Attribute
 ///
 /// Any attribute named "ModMenuIgnoreAttribute" will be treated the same for this functionality, so you can opt-out of ModMenu behaviors without adding ModMenu as a dependency.
 /// </summary>
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Field, AllowMultiple = false)]
+[AttributeUsage(
+    AttributeTargets.Class | AttributeTargets.Field | AttributeTargets.Property,
+    AllowMultiple = false
+)]
 public class ModMenuIgnoreAttribute : Attribute { }
 
 internal static class AttributeExtensions


### PR DESCRIPTION
### Summary of Changes

Since ModMenuGenerator supports properties, we should allow the canonical Attribute to target properties.

### Checklist

* No change is too small for a release, so pick one:
  * [x] I have updated the package version following semantic versioning
  * [ ] There is another change actively WIP that will update the version (link issue or PR here)
  * [ ] This PR does not update user-facing code/config
  * [ ] I'm not sure how to set the version and would like the reviewer's help
  
