### PR TITLE
Tidy up ModMenuGenerator versioning

### DIFF
--- a/Silksong.ModMenuAnalyzers/ModMenuGenerator.cs
+++ b/Silksong.ModMenuAnalyzers/ModMenuGenerator.cs
@@ -14,7 +14,9 @@ namespace Silksong.ModMenuAnalyzers;
 [Generator(LanguageNames.CSharp)]
 public class ModMenuGenerator : IIncrementalGenerator
 {
-    public const string VERSION = "0.7.1";
+    public static readonly string VERSION = typeof(ModMenuGenerator)
+        .Assembly.GetName()
+        .Version.ToString();
 
     /// <inheritdoc/>
     public void Initialize(IncrementalGeneratorInitializationContext context)

--- a/Silksong.ModMenuAnalyzers/Silksong.ModMenuAnalyzers.csproj
+++ b/Silksong.ModMenuAnalyzers/Silksong.ModMenuAnalyzers.csproj
@@ -1,4 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import
+    Condition="Exists('../Silksong.ModMenu/Directory.Build.props')"
+    Project="../Silksong.ModMenu/Directory.Build.props"
+  />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
### Summary of Changes

Technically the current release generates files with the wrong version but I don't think that's critical, this is about future-proofing.  There are multiple other PRs en route to land soon that will bump the version anyway.

### Checklist

* No change is too small for a release, so pick one:
  * [ ] I have updated the package version following semantic versioning
  * [ ] There is another change actively WIP that will update the version (link issue or PR here)
  * [x] This PR does not update user-facing code/config
  * [ ] I'm not sure how to set the version and would like the reviewer's help
  
